### PR TITLE
Fix muddle not found issue for font-awesome-styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-require("style!css!sass!./font-awesome-styles!./font-awesome.config.js");
+require("style!css!sass!./font-awesome-styles.loader!./font-awesome.config.js");


### PR DESCRIPTION
- this happens in webpack 2

I did a quick test to see whether this change impacts anything in default bootstrap-loader basic example and it worked fine.